### PR TITLE
Skip UniV3 Vaults (for now), add documentation

### DIFF
--- a/SUBGRAPH_DEVELOPMENT.md
+++ b/SUBGRAPH_DEVELOPMENT.md
@@ -1,0 +1,33 @@
+## Subgraph Development
+
+The current easiest way that to develop this subgraph is as follows:
+
+1. Clone this repo to your machine and `npm install`
+2. Visit https://thegraph.com/ and create a new subgraph titled "Harvest Finance Development $YOUR_NAME". Make sure to set it to "hidden" so that it does not appear in search results
+3. If you have not yet used `graph-cli`, run `graph auth https://api.thegraph.com/deploy/ $YOUR_TOKEN` with the token you received from thegraph.com
+
+Now you are ready to make some changes.
+
+When you are ready to deploy your changes, run the following commands:
+
+1. `npm run codegen` (autogenerates code from schema mappings)
+2. `npm run build`
+3. Deploy to your personal subgraph with:
+
+```sh
+graph deploy --node https://api.thegraph.com/deploy/ \
+             --ipfs https://api.thegraph.com/ipfs/ \
+             $GITHUB_USER/$STAGING_GRAPH_NAME
+
+```
+
+4. You can then visit your personal subgraph's page to verify that your changes are indexing properly.
+
+
+#### Local node
+
+It is also possible to run these tasks with a local graph node, which removes the dependency on a remote service. This might be beneficial if you are getting errors and need better visibility into why they are occurring.
+
+To run a local node, follow the instructions at [graphprotocol/graph-node](https://github.com/graphprotocol/graph-node). Edit the `docker-compose.yml` to point at a remote Ethereum RPC, **however** it needs to support the trace module. (As of writing: Alchemy does, Infura does not.)
+
+Then, you can run `npm run create-local` and `npm run deploy-local` to deploy your subgraph to your local node.

--- a/schema.graphql
+++ b/schema.graphql
@@ -23,6 +23,11 @@ type Vault @entity {
   deposits: [Deposit!]! @derivedFrom(field: "vault")
 }
 
+type NewUniVault @entity {
+  "address of the vault"
+  id: ID!
+}
+
 type Strategy @entity {
   "strategy address"
   id: ID!

--- a/src/ControllerListener.ts
+++ b/src/ControllerListener.ts
@@ -46,7 +46,7 @@ export function handleAddVaultAndStrategy(call: AddVaultAndStrategyCall): void {
 
     let vault = Vault.load(vault_addr.toHex())
     if (vault == null) {
-      vault = createVaultAndStrategy(vault_addr, strategy_addr, call.block, call.transaction)
+      createVaultAndStrategy(vault_addr, strategy_addr, call.block, call.transaction)
 
     }
   } else {

--- a/src/utils/Vault.ts
+++ b/src/utils/Vault.ts
@@ -7,7 +7,7 @@ import { VaultListener } from '../../generated/templates'
 import { VaultContract } from "../../generated/ControllerListener/VaultContract"
 
 // schema imports
-import { Vault, Strategy } from "../../generated/schema"
+import { Vault, Strategy, NewUniVault } from "../../generated/schema"
 
 // helper function import
 import { createStrategy } from "./Strategy"
@@ -20,34 +20,35 @@ export function createVaultAndStrategy
   strategy_addr: Address,
   eth_block: ethereum.Block,
   eth_transaction: ethereum.Transaction
-): Vault
+): void
 {
   let vault_contract = VaultContract.bind(vault_addr)
-  let underlying_addr = vault_contract.try_underlying()
+  let underlying_addr = vault_contract.underlying()
 
-  // No support via UniV3 yet
-  if (!underlying_addr) return null;
+  if (!underlying_addr) {
+    let newUniVault = new NewUniVault(vault_addr.toHex())
+    newUniVault.save()
+  } else {
+    let underlying_token = loadOrCreateERC20DetailedToken(<Address> underlying_addr)
+    let f_token = loadOrCreateERC20DetailedToken(vault_addr)
 
-  let underlying_token = loadOrCreateERC20DetailedToken(<Address> underlying_addr)
-  let f_token = loadOrCreateERC20DetailedToken(vault_addr)
+    let transaction = loadOrCreateTransaction(eth_transaction, eth_block)
 
-  let transaction = loadOrCreateTransaction(eth_transaction, eth_block)
+    let vault = new Vault(vault_addr.toHex())
+    vault.timestamp = transaction.timestamp
+    vault.transaction = transaction.id
+    vault.underlying = underlying_token.id
+    vault.fToken = f_token.id
 
-  let vault = new Vault(vault_addr.toHex())
-  vault.timestamp = transaction.timestamp
-  vault.transaction = transaction.id
-  vault.underlying = underlying_token.id
-  vault.fToken = f_token.id
+    // strategy cannot exist yet because it is unique to a vault and the only way
+    // for the enitity to be created is by getting here or the vault was already
+    // being listened to, which means the vault already exist so we wouldnt be here
+    let strategy = createStrategy(strategy_addr, vault_addr, eth_block, eth_transaction)
 
-  // strategy cannot exist yet because it is unique to a vault and the only way
-  // for the enitity to be created is by getting here or the vault was already
-  // being listened to, which means the vault already exist so we wouldnt be here
-  let strategy = createStrategy(strategy_addr, vault_addr, eth_block, eth_transaction)
+    vault.currStrategy = strategy.id
 
-  vault.currStrategy = strategy.id
+    vault.save()
 
-  vault.save()
-
-  VaultListener.create(vault_addr)
-  return vault
+    VaultListener.create(vault_addr)
+  }
 }

--- a/src/utils/Vault.ts
+++ b/src/utils/Vault.ts
@@ -23,9 +23,12 @@ export function createVaultAndStrategy
 ): Vault
 {
   let vault_contract = VaultContract.bind(vault_addr)
-  let underlying_addr = vault_contract.underlying()
+  let underlying_addr = vault_contract.try_underlying()
 
-  let underlying_token = loadOrCreateERC20DetailedToken(underlying_addr)
+  // No support via UniV3 yet
+  if (!underlying_addr) return null;
+
+  let underlying_token = loadOrCreateERC20DetailedToken(<Address> underlying_addr)
   let f_token = loadOrCreateERC20DetailedToken(vault_addr)
 
   let transaction = loadOrCreateTransaction(eth_transaction, eth_block)

--- a/src/utils/Vault.ts
+++ b/src/utils/Vault.ts
@@ -23,13 +23,13 @@ export function createVaultAndStrategy
 ): void
 {
   let vault_contract = VaultContract.bind(vault_addr)
-  let underlying_addr = vault_contract.underlying()
+  let underlying_addr_call = vault_contract.try_underlying()
 
-  if (!underlying_addr) {
+  if (underlying_addr_call.reverted) {
     let newUniVault = new NewUniVault(vault_addr.toHex())
     newUniVault.save()
   } else {
-    let underlying_token = loadOrCreateERC20DetailedToken(<Address> underlying_addr)
+    let underlying_token = loadOrCreateERC20DetailedToken(<Address> underlying_addr_call.value)
     let f_token = loadOrCreateERC20DetailedToken(vault_addr)
 
     let transaction = loadOrCreateTransaction(eth_transaction, eth_block)

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -15,6 +15,7 @@ dataSources:
       language: wasm/assemblyscript
       entities:
         - Vault
+        - NewUniVault
         - Strategy
         - Token
       abis:


### PR DESCRIPTION
Subgraph is getting caught on the univ3 vaults and not updating.

We need contracts code from Bread before we can do anything about it.

FYI, we don't seem to be able to call the entity "UniV3Vault", I suspect it does not like the number `3` in there. 

I added some documentation on how to develop this subgraph for those of us (like me) who are uninitiated.

This is currently indexing here: https://thegraph.com/explorer/subgraph/ajb/harvest-finance-dev-ajb?version=pending

If this is approved, we should deploy it so that our official subgraph can get caught up.
